### PR TITLE
Fix paths for dependency styles requirements

### DIFF
--- a/packages/boundless-checkbox-group/style.styl
+++ b/packages/boundless-checkbox-group/style.styl
@@ -1,5 +1,5 @@
 @require "variables"
-@require "node_modules/boundless-checkbox/style";
+@require "../boundless-checkbox/style";
 
 // Skin-specific styles go here. Demo-specific styles go in demo/style.styl.
 

--- a/packages/boundless-modal/style.styl
+++ b/packages/boundless-modal/style.styl
@@ -1,5 +1,5 @@
 @require "variables"
-@require "node_modules/boundless-dialog/style";
+@require "../boundless-dialog/style";
 
 // Skin-specific styles go here. Demo-specific styles go in demo/style.styl.
 

--- a/packages/boundless-pagination/style.styl
+++ b/packages/boundless-pagination/style.styl
@@ -1,5 +1,5 @@
 @require "variables"
-@require "node_modules/boundless-segmented-control/style";
+@require "../boundless-segmented-control/style";
 
 // Skin-specific styles go here. Demo-specific styles go in demo/style.styl.
 

--- a/packages/boundless-popover/style.styl
+++ b/packages/boundless-popover/style.styl
@@ -1,5 +1,5 @@
 @require "variables"
-@require "node_modules/boundless-dialog/style";
+@require "../boundless-dialog/style";
 
 // Skin-specific styles go here. Demo-specific styles go in demo/style.styl.
 

--- a/packages/boundless-progress/style.styl
+++ b/packages/boundless-progress/style.styl
@@ -1,5 +1,5 @@
 @require "variables"
-@require "node_modules/boundless-button/style"
+@require "../boundless-button/style"
 
 // Skin-specific styles go here. Demo-specific styles go in demo/style.styl.
 

--- a/packages/boundless-segmented-control/style.styl
+++ b/packages/boundless-segmented-control/style.styl
@@ -1,5 +1,5 @@
 @require "variables"
-@require "node_modules/boundless-button/style"
+@require "../boundless-button/style"
 
 // Skin-specific styles go here. Demo-specific styles go in demo/style.styl.
 

--- a/packages/boundless-tokenized-input/style.styl
+++ b/packages/boundless-tokenized-input/style.styl
@@ -1,5 +1,5 @@
 @require "variables"
-@require "node_modules/boundless-typeahead/style"
+@require "../boundless-typeahead/style"
 
 // Skin-specific styles go here. Demo-specific styles go in demo/style.styl.
 

--- a/packages/boundless-typeahead/style.styl
+++ b/packages/boundless-typeahead/style.styl
@@ -1,5 +1,5 @@
 @require "variables"
-@require "node_modules/boundless-input/style"
+@require "../boundless-input/style"
 
 // Skin-specific styles go here. Demo-specific styles go in demo/style.styl.
 


### PR DESCRIPTION
Importing the master styles does not work in the manner described in the Getting Started page.

~One problem is that there is no package-specific `variables.styl` anymore so the `@require` path in each package's `style.styl` causes an error.~

The other problem is that packages that depend on other packages have a second `@require` statement in their `style.styl` that points to the dependency's `style.styl`. This path is not correct.

With these changes it should be possible to do either of these combos in a project's main styles:

```stylus
@require "../node_modules/boundless/variables"

// take 'em all
@require "../node_modules/boundless/style"
```

```stylus
@require "../node_modules/boundless/variables"

// take what you need
@require "../node_modules/boundless-pagination/style" // depends on `boundless-segmented-control`
```